### PR TITLE
update telerik url dropdownlist

### DIFF
--- a/Ocaramba.Tests.PageObjects/PageObjects/Kendo/KendoDropDownListPage.cs
+++ b/Ocaramba.Tests.PageObjects/PageObjects/Kendo/KendoDropDownListPage.cs
@@ -40,7 +40,7 @@ namespace Ocaramba.Tests.PageObjects.PageObjects.Kendo
             capColorKendoDropDownListLocator = new ElementLocator(Locator.CssSelector, "span[aria-owns='color_listbox']"),
             capSizeKendoDropDownListLocator = new ElementLocator(Locator.CssSelector, "span[aria-owns='size_listbox']");
 
-        private readonly Uri url = new Uri("http://demos.telerik.com/jsp-ui/dropdownlist/index");
+        private readonly Uri url = new Uri("http://demos.telerik.com/jsp-ui/dropdownlist/basic-usage");
 
         public KendoDropDownListPage(DriverContext driverContext)
             : base(driverContext)


### PR DESCRIPTION
Telerik changed their default dropdownlist example. Updated the url of the example used in the tests